### PR TITLE
Add Limbo to intersectional job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A living document of resources for diversity in hiring : job boards, organizatio
 
 * [Blendoor](http://blendoor.com) : a job-matching app that hides candidates' name, photo, gender and race information, only highlighting what's relevant to the job listing, like professional history and educational background.
 * [Jopwell](https://www.jopwell.com/) : a career advancement platform for Black, Latino/Hispanic, and Native American students and professionals.
+* [Limbo](https://www.limbo.io) : an open & anonymous job platform for quietly looking for a new role. Hides candidates' name, gender and race information. Allows users to optionally identify as members of an underrepresented group.
 * [People Of Color In Tech (POCIT)](http://peopleofcolorintech.com/) : A patreon-supported independent community job board for people of color in technology. The site includes job postings and advice columns.
 * [Tech Connection](https://www.thetechconnectioninc.com)  :  a recruitment platform dedicated to improving the success rates of underrepresented talents.
 


### PR DESCRIPTION
Hey Nassim! Been a while - hope you're well.

This is a great document. I wanted to propose adding [Limbo](https://www.limbo.io) to the intersectional job boards section. Full disclosure, it's the company I've created so I am biased, but reducing top of funnel bias is a primary goal for it.

More on it here if you're curious: https://medium.com/@chrisdary/introducing-limbo-ddb97a67ff63

Feel free to alter the copy entirely, just wanted to put something out there. If you feel like it's not a fit, no problem.