### PR TITLE
add humanpredictions to intersectional job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ A living document of resources for diversity in hiring : job boards, organizatio
 ### Intersectional
 
 * [Blendoor](http://blendoor.com) : a job-matching app that hides candidates' name, photo, gender and race information, only highlighting what's relevant to the job listing, like professional history and educational background.
+* [humanpredictions](http://humanpredictions.io) : a recruitment product using predictive analytics recently launched an [open source diversity feature](https://github.com/humanpredictions/diversity) to help companies partner with underrepresented folks and people diversifying the the tech industry.
 * [Jopwell](https://www.jopwell.com/) : a career advancement platform for Black, Latino/Hispanic, and Native American students and professionals.
 * [Limbo](https://www.limbo.io) : an open & anonymous job platform for quietly looking for a new role. Hides candidates' name, gender and race information. Allows users to optionally identify as members of an underrepresented group.
 * [People Of Color In Tech (POCIT)](http://peopleofcolorintech.com/) : A patreon-supported independent community job board for people of color in technology. The site includes job postings and advice columns.
 * [Tech Connection](https://www.thetechconnectioninc.com)  :  a recruitment platform dedicated to improving the success rates of underrepresented talents.
+
 
 
 ### Gender focused


### PR DESCRIPTION
Hey Nassim! 

What a cool resource you've created! I've been doing similar work and actually wrote this blog (http://blog.humanpredictions.io/intentional-recruiting-for-diversity/) back in the fall which is what recently led me to you. A reader of mine followed up with me sharing your GitHub project. 

I wanted to propose adding humanpredictions to the intersectional section because of the open source project we're working on. It doesn't predict if someone is a diverse candidate, because that feels very wrong and unsafe. Instead it surfaces people by way of public data who are actively engaged with communities that support and advocate for underrepresented groups to help companies think about sourcing and recruitment differently. 

Completely understand if you don't feel it meets the cut, but I'd love to help you share more resources any way I can. Keep up the awesome work and contributions! 

Thanks for all you're doing 
-- Lia